### PR TITLE
Refactor the product_categories method to accept a context parameter and update the getList function call accordingly.

### DIFF
--- a/src/Resources/BaseResource.php
+++ b/src/Resources/BaseResource.php
@@ -38,11 +38,12 @@ abstract class BaseResource
         return $params;
     }
 
-    protected function getList(string $url, bool $forceUrl = false): array
+    protected function getList(string $url, bool $forceUrl = false, array $data = []): array
     {
         return $this->requestData(
             method: 'get',
             path: $url,
+            data: $data,
             forceUrl: $forceUrl
         );
     }

--- a/src/Resources/Info.php
+++ b/src/Resources/Info.php
@@ -61,9 +61,9 @@ class Info extends BaseResource
         return $this->getList('measures', true);
     }
 
-    public function product_categories(): array
+    public function product_categories(string $context): array
     {
-        return $this->getList('product_categories');
+        return $this->getList('product_categories', data: ['context' => $context]);
     }
 
     public function received_document_categories(): array


### PR DESCRIPTION
Commit Description:
 - This MR refactors the product_categories method in the PHP code to accept a context parameter, mandatory in API v2 and update the getList function call with the new parameter.
 - The context parameter is required and must be a string. It could include one of the values 'products | issued_documents | received_documents' as specified in the original API reference.